### PR TITLE
Added Canva in Assiqnments, Quiz typpe in Quiz, Added Program linked …

### DIFF
--- a/tap_lms/tap_lms/doctype/assignment_submission_media_link/assignment_submission_media_link.json
+++ b/tap_lms/tap_lms/doctype/assignment_submission_media_link/assignment_submission_media_link.json
@@ -17,7 +17,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Link Type",
-   "options": "Drive\nYouTube",
+   "options": "Drive\nYouTube\nCanva",
    "reqd": 1
   },
   {

--- a/tap_lms/tap_lms/doctype/batch/batch.json
+++ b/tap_lms/tap_lms/doctype/batch/batch.json
@@ -11,6 +11,7 @@
  "engine": "InnoDB",
  "field_order": [
   "name1",
+  "program",
   "start_date",
   "end_date",
   "title",
@@ -32,6 +33,14 @@
    "label": "Name",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "program",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Program",
+   "options": "Program",
+   "reqd": 1
   },
   {
    "fieldname": "start_date",
@@ -99,7 +108,6 @@
    "label": "Grace Window Days"
   },
   {
-   "description": "Advances weekly via cron or admin action. Controls binge limit.",
    "fieldname": "current_calendar_week",
    "fieldtype": "Int",
    "label": "Current Calendar Week",
@@ -108,7 +116,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-04 20:18:14.926501",
+ "modified": "2026-05-16 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Tap Lms",
  "name": "Batch",

--- a/tap_lms/tap_lms/doctype/course_level/course_level.json
+++ b/tap_lms/tap_lms/doctype/course_level/course_level.json
@@ -9,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "name1",
+  "program",
   "vertical",
   "level",
   "stage",
@@ -26,6 +27,13 @@
    "fieldname": "name1",
    "fieldtype": "Data",
    "label": "Name"
+  },
+  {
+   "fieldname": "program",
+   "fieldtype": "Link",
+   "label": "Program",
+   "options": "Program",
+   "reqd": 1
   },
   {
    "fieldname": "vertical",
@@ -92,7 +100,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-10 00:12:55.560514",
+ "modified": "2026-05-16 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Tap Lms",
  "name": "Course Level",

--- a/tap_lms/tap_lms/doctype/program/program.js
+++ b/tap_lms/tap_lms/doctype/program/program.js
@@ -1,0 +1,129 @@
+frappe.ui.form.on("Program", {
+
+    refresh(frm) {
+        frm.trigger("add_custom_buttons");
+        frm.trigger("render_dashboard_headline");
+    },
+
+    add_custom_buttons(frm) {
+        if (!frm.is_new()) {
+            frm.add_custom_button(
+                __("Create Batch"),
+                () => {
+                    frappe.new_doc("Batch", { program: frm.doc.name });
+                },
+                __("Actions")
+            );
+
+            frm.add_custom_button(
+                __("View Batches"),
+                () => {
+                    frappe.set_route("List", "Batch", { program: frm.doc.name });
+                },
+                __("Actions")
+            );
+
+            frm.add_custom_button(
+                __("View Course Levels"),
+                () => {
+                    frappe.set_route("List", "Course Level", { program: frm.doc.name });
+                },
+                __("Actions")
+            );
+
+            frm.add_custom_button(
+                __("Program Summary"),
+                () => {
+                    frappe.call({
+                        method: "tap_lms.tap_lms.doctype.program.program.get_program_summary",
+                        args: { program_name: frm.doc.name },
+                        callback(r) {
+                            if (r.message) {
+                                const d = r.message;
+
+                                const batch_rows = d.batches.map(b => `
+                                    <tr>
+                                        <td>${b.name1 || "-"}</td>
+                                        <td>${b.batch_id || "-"}</td>
+                                        <td>${b.start_date || "-"}</td>
+                                        <td>${b.end_date || "-"}</td>
+                                        <td>${b.active ? "Yes" : "No"}</td>
+                                    </tr>
+                                `).join("");
+
+                                const course_rows = d.course_levels.map(c => `
+                                    <tr>
+                                        <td>${c.name1 || "-"}</td>
+                                        <td>${c.vertical || "-"}</td>
+                                        <td>${c.stage || "-"}</td>
+                                        <td>${c.kit_less ? "Yes" : "No"}</td>
+                                    </tr>
+                                `).join("");
+
+                                frappe.msgprint({
+                                    title: __("Program Summary"),
+                                    message: `
+                                        <p><b>Program:</b> ${d.program || "-"}</p>
+                                        <p><b>Total Batches:</b> ${d.total_batches} &nbsp;|&nbsp; <b>Active:</b> ${d.active_batches}</p>
+                                        <p><b>Total Course Levels:</b> ${d.total_course_levels}</p>
+
+                                        <h6 style="margin-top:12px;">Batches</h6>
+                                        <table class="table table-bordered">
+                                            <thead>
+                                                <tr>
+                                                    <th>Name</th>
+                                                    <th>Batch ID</th>
+                                                    <th>Start</th>
+                                                    <th>End</th>
+                                                    <th>Active</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>${batch_rows || "<tr><td colspan='5'>No batches found.</td></tr>"}</tbody>
+                                        </table>
+
+                                        <h6 style="margin-top:12px;">Course Levels</h6>
+                                        <table class="table table-bordered">
+                                            <thead>
+                                                <tr>
+                                                    <th>Name</th>
+                                                    <th>Vertical</th>
+                                                    <th>Stage</th>
+                                                    <th>Kit Less</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>${course_rows || "<tr><td colspan='4'>No course levels found.</td></tr>"}</tbody>
+                                        </table>
+                                    `,
+                                    indicator: "blue",
+                                });
+                            }
+                        },
+                    });
+                },
+                __("Actions")
+            );
+        }
+    },
+
+    render_dashboard_headline(frm) {
+        if (frm.is_new()) return;
+
+        frappe.call({
+            method: "tap_lms.tap_lms.doctype.program.program.get_program_summary",
+            args: { program_name: frm.doc.name },
+            callback(r) {
+                if (r.message) {
+                    const d = r.message;
+                    frm.dashboard.set_headline_alert(
+                        __("{0} batch(es) — {1} active &nbsp;|&nbsp; {2} course level(s)", [
+                            d.total_batches,
+                            d.active_batches,
+                            d.total_course_levels,
+                        ]),
+                        d.active_batches > 0 ? "green" : "orange"
+                    );
+                }
+            },
+        });
+    },
+});

--- a/tap_lms/tap_lms/doctype/program/program.json
+++ b/tap_lms/tap_lms/doctype/program/program.json
@@ -1,0 +1,47 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:{program}",
+ "creation": "2026-05-16 00:00:00.000000",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "program"
+ ],
+ "fields": [
+  {
+   "fieldname": "program",
+   "fieldtype": "Data",
+   "label": "Program",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-05-16 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Tap Lms",
+ "name": "Program",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/tap_lms/tap_lms/doctype/program/program.py
+++ b/tap_lms/tap_lms/doctype/program/program.py
@@ -1,0 +1,64 @@
+import frappe
+from frappe.model.document import Document
+
+
+class Program(Document):
+
+    def after_insert(self):
+        frappe.msgprint(
+            frappe._("Program {0} created successfully.").format(self.name),
+            indicator="green",
+            alert=True,
+        )
+
+
+@frappe.whitelist()
+def get_batches(program_name):
+    return frappe.get_all(
+        "Batch",
+        filters={"program": program_name},
+        fields=[
+            "name",
+            "name1",
+            "batch_id",
+            "start_date",
+            "end_date",
+            "active",
+            "regist_end_date",
+            "program_type",
+            "total_weeks",
+            "current_calendar_week",
+        ],
+        order_by="start_date asc",
+    )
+
+
+@frappe.whitelist()
+def get_course_levels(program_name):
+    return frappe.get_all(
+        "Course Level",
+        filters={"program": program_name},
+        fields=[
+            "name",
+            "name1",
+            "vertical",
+            "stage",
+            "kit_less",
+        ],
+        order_by="name1 asc",
+    )
+
+
+@frappe.whitelist()
+def get_program_summary(program_name):
+    doc = frappe.get_doc("Program", program_name)
+    batches = get_batches(program_name)
+    course_levels = get_course_levels(program_name)
+    return {
+        "program": doc.program,
+        "total_batches": len(batches),
+        "active_batches": len([b for b in batches if b.active]),
+        "total_course_levels": len(course_levels),
+        "batches": batches,
+        "course_levels": course_levels,
+    }

--- a/tap_lms/tap_lms/doctype/program/test_program.py
+++ b/tap_lms/tap_lms/doctype/program/test_program.py
@@ -1,0 +1,150 @@
+import frappe
+import unittest
+from frappe.utils import add_days, nowdate
+
+
+class TestProgram(unittest.TestCase):
+
+    def setUp(self):
+        self.program_data = {
+            "doctype": "Program",
+            "program": "Test Program",
+        }
+        self.batch_base = {
+            "doctype": "Batch",
+            "name1": "Test Batch",
+            "batch_id": "BATCH-T001",
+            "start_date": nowdate(),
+            "end_date": add_days(nowdate(), 30),
+            "active": 1,
+            "regist_end_date": add_days(nowdate(), -1),
+            "current_calendar_week": 1,
+        }
+        self.course_level_base = {
+            "doctype": "Course Level",
+            "name1": "Test Course Level",
+        }
+
+    def tearDown(self):
+        frappe.db.rollback()
+
+    def make_program(self, **overrides):
+        data = {**self.program_data, **overrides}
+        doc = frappe.get_doc(data)
+        doc.insert(ignore_permissions=True)
+        return doc
+
+    def make_batch(self, program_name, **overrides):
+        data = {**self.batch_base, "program": program_name, **overrides}
+        doc = frappe.get_doc(data)
+        doc.insert(ignore_permissions=True)
+        return doc
+
+    def make_course_level(self, program_name, **overrides):
+        data = {**self.course_level_base, "program": program_name, **overrides}
+        doc = frappe.get_doc(data)
+        doc.insert(ignore_permissions=True)
+        return doc
+
+    def test_program_creation(self):
+        doc = self.make_program()
+        self.assertTrue(frappe.db.exists("Program", doc.name))
+
+    def test_multiple_batches_link_to_one_program(self):
+        prog = self.make_program()
+        self.make_batch(prog.name, batch_id="BATCH-MULTI-001", name1="Batch One")
+        self.make_batch(prog.name, batch_id="BATCH-MULTI-002", name1="Batch Two")
+        batches = frappe.get_all("Batch", filters={"program": prog.name})
+        self.assertEqual(len(batches), 2)
+
+    def test_multiple_course_levels_link_to_one_program(self):
+        prog = self.make_program()
+        self.make_course_level(prog.name, name1="Course Level One")
+        self.make_course_level(prog.name, name1="Course Level Two")
+        course_levels = frappe.get_all("Course Level", filters={"program": prog.name})
+        self.assertEqual(len(course_levels), 2)
+
+    def test_get_batches_returns_correct_program(self):
+        prog = self.make_program()
+        self.make_batch(prog.name, batch_id="BATCH-GET-001", name1="Batch Get")
+        result = frappe.call(
+            "tap_lms.tap_lms.doctype.program.program.get_batches",
+            program_name=prog.name,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["batch_id"], "BATCH-GET-001")
+
+    def test_get_batches_empty_for_new_program(self):
+        prog = self.make_program()
+        result = frappe.call(
+            "tap_lms.tap_lms.doctype.program.program.get_batches",
+            program_name=prog.name,
+        )
+        self.assertEqual(result, [])
+
+    def test_get_course_levels_returns_correct_program(self):
+        prog = self.make_program()
+        self.make_course_level(prog.name, name1="Level Alpha")
+        result = frappe.call(
+            "tap_lms.tap_lms.doctype.program.program.get_course_levels",
+            program_name=prog.name,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name1"], "Level Alpha")
+
+    def test_get_course_levels_empty_for_new_program(self):
+        prog = self.make_program()
+        result = frappe.call(
+            "tap_lms.tap_lms.doctype.program.program.get_course_levels",
+            program_name=prog.name,
+        )
+        self.assertEqual(result, [])
+
+    def test_get_program_summary_batch_counts(self):
+        prog = self.make_program()
+        self.make_batch(prog.name, batch_id="BATCH-SUM-001", name1="Active Batch", active=1)
+        self.make_batch(prog.name, batch_id="BATCH-SUM-002", name1="Inactive Batch", active=0)
+        result = frappe.call(
+            "tap_lms.tap_lms.doctype.program.program.get_program_summary",
+            program_name=prog.name,
+        )
+        self.assertEqual(result["total_batches"], 2)
+        self.assertEqual(result["active_batches"], 1)
+
+    def test_get_program_summary_course_level_count(self):
+        prog = self.make_program()
+        self.make_course_level(prog.name, name1="Level One")
+        self.make_course_level(prog.name, name1="Level Two")
+        result = frappe.call(
+            "tap_lms.tap_lms.doctype.program.program.get_program_summary",
+            program_name=prog.name,
+        )
+        self.assertEqual(result["total_course_levels"], 2)
+
+    def test_get_program_summary_fields(self):
+        prog = self.make_program()
+        result = frappe.call(
+            "tap_lms.tap_lms.doctype.program.program.get_program_summary",
+            program_name=prog.name,
+        )
+        self.assertIn("program", result)
+        self.assertIn("total_batches", result)
+        self.assertIn("active_batches", result)
+        self.assertIn("total_course_levels", result)
+        self.assertIn("batches", result)
+        self.assertIn("course_levels", result)
+
+    def test_batch_requires_program_link(self):
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            frappe.get_doc({
+                **self.batch_base,
+                "batch_id": "BATCH-NOLINK-001",
+                "name1": "No Link Batch",
+            }).insert(ignore_permissions=True)
+
+    def test_course_level_requires_program_link(self):
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            frappe.get_doc({
+                **self.course_level_base,
+                "name1": "No Link Level",
+            }).insert(ignore_permissions=True)

--- a/tap_lms/tap_lms/doctype/quiz/quiz.json
+++ b/tap_lms/tap_lms/doctype/quiz/quiz.json
@@ -11,6 +11,7 @@
   "quiz_name",
   "description",
   "difficulty_tier",
+  "quiz_type",
   "questions",
   "passing_score",
   "time_limit",
@@ -30,6 +31,12 @@
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "label": "Description"
+  },
+  {
+   "fieldname": "quiz_type",
+   "fieldtype": "Select",
+   "label": "Quiz Type",
+   "options": "Main\nPlio"
   },
   {
    "fieldname": "questions",


### PR DESCRIPTION
This pull request introduces a new "Program" entity to the TAP LMS, establishes strong links between programs, batches, and course levels, and enhances the user interface and data integrity for managing these relationships. It also adds new fields to support richer metadata and filtering, and improves test coverage for the new features.

**Program Entity & Relationships**

* Added a new `Program` DocType (`program.json`) with required permissions and tracking, and implemented its backend logic (`program.py`). This includes methods to retrieve batches, course levels, and program summaries related to a program. [[1]](diffhunk://#diff-47051c2dbf90e3c93d31b5a7bcba7d257575b1520adb937f75afa0ec0f0797faR1-R47) [[2]](diffhunk://#diff-3e36d38d17ad67d47ff91f104b728292593d469555003852a082e5dbf0bf6b84R1-R64)
* Updated `Batch` and `Course Level` DocTypes to include a required link to `Program`, ensuring every batch and course level is associated with a program. The field order was updated to reflect this relationship. [[1]](diffhunk://#diff-f5552a1c94c1787a9ff78ff9ebe1815405a693819245c90723b8f97ce7ac6e87R14) [[2]](diffhunk://#diff-f5552a1c94c1787a9ff78ff9ebe1815405a693819245c90723b8f97ce7ac6e87R37-R44) [[3]](diffhunk://#diff-73f3a8c32f16950e0ad27f9f2ddb69c5beb4f58327f7685ef79d60e05df29a18R12) [[4]](diffhunk://#diff-73f3a8c32f16950e0ad27f9f2ddb69c5beb4f58327f7685ef79d60e05df29a18R31-R37)

**User Interface Enhancements**

* Added a client-side script for the `Program` form (`program.js`) to provide custom actions: create/view batches, view course levels, and display a program summary dashboard, improving navigation and data visibility for users.

**Testing and Data Integrity**

* Introduced comprehensive unit tests for the new `Program` functionality, including validation that batches and course levels must be linked to a program.

**Other Model Improvements**

* Added a new "Quiz Type" field to the `Quiz` DocType, allowing selection between "Main" and "Plio" quiz types. [[1]](diffhunk://#diff-b5a001869881e757ea584099900678d638afc237d18755691f0308621b528f46R14) [[2]](diffhunk://#diff-b5a001869881e757ea584099900678d638afc237d18755691f0308621b528f46R35-R40)
* Expanded the allowed "Link Type" options in `Assignment Submission Media Link` to include "Canva".

**Metadata and Maintenance**

* Updated the `modified` timestamps in affected DocTypes to reflect the latest changes. [[1]](diffhunk://#diff-f5552a1c94c1787a9ff78ff9ebe1815405a693819245c90723b8f97ce7ac6e87L111-R119) [[2]](diffhunk://#diff-73f3a8c32f16950e0ad27f9f2ddb69c5beb4f58327f7685ef79d60e05df29a18L95-R103)

---

**References:**  
[[1]](diffhunk://#diff-47051c2dbf90e3c93d31b5a7bcba7d257575b1520adb937f75afa0ec0f0797faR1-R47) [[2]](diffhunk://#diff-3e36d38d17ad67d47ff91f104b728292593d469555003852a082e5dbf0bf6b84R1-R64) [[3]](diffhunk://#diff-f5552a1c94c1787a9ff78ff9ebe1815405a693819245c90723b8f97ce7ac6e87R14) [[4]](diffhunk://#diff-f5552a1c94c1787a9ff78ff9ebe1815405a693819245c90723b8f97ce7ac6e87R37-R44) [[5]](diffhunk://#diff-73f3a8c32f16950e0ad27f9f2ddb69c5beb4f58327f7685ef79d60e05df29a18R12) [[6]](diffhunk://#diff-73f3a8c32f16950e0ad27f9f2ddb69c5beb4f58327f7685ef79d60e05df29a18R31-R37) [[7]](diffhunk://#diff-bc748bf4c3b810f73d062b40e2567fe979ca1698ca709f16d09aa2108c816db3R1-R129) [[8]](diffhunk://#diff-01be6c0f1efb7a455c591d22b042b18aa3e63fa41ed561e2f75b9a4f4f8172b8R1-R150) [[9]](diffhunk://#diff-b5a001869881e757ea584099900678d638afc237d18755691f0308621b528f46R14) [[10]](diffhunk://#diff-b5a001869881e757ea584099900678d638afc237d18755691f0308621b528f46R35-R40) [[11]](diffhunk://#diff-4d61cd4f151c0240084e8ef0c1bdff9fa3131e1b1570a8d4dabe6c38fff89e6cL20-R20) [[12]](diffhunk://#diff-f5552a1c94c1787a9ff78ff9ebe1815405a693819245c90723b8f97ce7ac6e87L111-R119) [[13]](diffhunk://#diff-73f3a8c32f16950e0ad27f9f2ddb69c5beb4f58327f7685ef79d60e05df29a18L95-R103)